### PR TITLE
fix typo

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -69,7 +69,7 @@ event-handler-webservice:
 kubeprometheusstack:
   nameOverride: kube-prometheus-stack
   fullnameOverride: kube-prometheus-stack
-  enable: true
+  enabled: true
   crds:
     enabled: true
   defaultRules:


### PR DESCRIPTION
> Helm’s condition handling is designed to fail open—if a condition is not explicitly set to false, the chart is installed.
This avoids accidentally disabling critical subcharts when a value is missing.