### PR TITLE
update chart to 0.7.0-dev

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 type: application
 name: mdai-hub
-version: 0.6.1
+version: 0.7.0-dev
 description: MDAI Hub helm chart
-appVersion: 0.6.1
+appVersion: 0.7.0-dev
 dependencies:
   - name: opentelemetry-operator
     version: ~0.71.2


### PR DESCRIPTION
This is the pattern I want to follow for `main` immediately after cutting mainline release tags