### PR TITLE
rename to gateway

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: rabbitmq
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.0.3
+  version: 16.0.4
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.71.3
@@ -17,14 +17,14 @@ dependencies:
 - name: mdai-operator
   repository: https://decisiveai.github.io/mdai-helm-charts
   version: 0.1.19
-- name: event-handler-webservice
+- name: mdai-gateway
   repository: https://decisiveai.github.io/mdai-helm-charts
-  version: 0.0.11
-- name: event-hub-poc
+  version: 0.0.12
+- name: mdai-event-hub
   repository: https://decisiveai.github.io/mdai-helm-charts
   version: 0.0.1
 - name: mdai-s3-logs-reader
   repository: https://decisiveai.github.io/mdai-helm-charts
   version: 0.0.2
-digest: sha256:6b0211e59886e5ca1af251eb0466652299790c5bc5b48ddb4e6099a8a672209d
-generated: "2025-05-28T17:30:00.766929-05:00"
+digest: sha256:c74fb13835c532b8d121646747df84fbca64b51b7d39237ea391e4ff01902dc2
+generated: "2025-05-30T14:42:02.360744-04:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -30,10 +30,10 @@ dependencies:
     version: 0.1.19
     repository: https://decisiveai.github.io/mdai-helm-charts
     condition: mdai-operator.enabled
-  - name: event-handler-webservice
-    version: 0.0.11
+  - name: mdai-gateway
+    version: 0.0.12
     repository: https://decisiveai.github.io/mdai-helm-charts
-    condition: event-handler-webservice.enabled
+    condition: mdai-gateway.enabled
   - name: mdai-event-hub
     version: 0.0.1
     repository: https://decisiveai.github.io/mdai-helm-charts

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ helm upgrade --install --create-namespace --namespace mdai --cleanup-on-fail --w
 
 ### ⚠️ Required Step: Self-observability setup ⚠️
 
-The mdai-helm-chart-installed mdai-operator and event-handler-webservice expect a destination to send their logs to, but this chart does not manage deploying the logs destination for those services. 
+The mdai-helm-chart-installed mdai-operator and mdai-gateway expect a destination to send their logs to, but this chart does not manage deploying the logs destination for those services. 
 
 The mdai-operator can manage an opinionated and configured collector called mdai-collector that will send logs from these services to S3.
 
@@ -59,15 +59,15 @@ spec:
      s3Bucket: "mdai-hub-logs"
 ```
 
-> ℹ️ The above name (`hub-monitor`) must correspond to the beginning of the host name in the `values.yaml` for the [operator](https://github.com/DecisiveAI/mdai-helm-chart/blob/422e1c345806f634ed92db2a67a672ed7e9c7101/values.yaml#L52) and [event-handler-webservice](https://github.com/DecisiveAI/mdai-helm-chart/blob/422e1c345806f634ed92db2a67a672ed7e9c7101/values.yaml#L59). So if the MdaiCollector resource name is `hub-monitor`, the corresponding service endpoint created is `http://hub-monitor-mdai-collector-service.mdai.svc.cluster.local:4318`.
+> ℹ️ The above name (`hub-monitor`) must correspond to the beginning of the host name in the `values.yaml` for the [operator](https://github.com/DecisiveAI/mdai-helm-chart/blob/422e1c345806f634ed92db2a67a672ed7e9c7101/values.yaml#L52) and [mdai-gateway](https://github.com/DecisiveAI/mdai-helm-chart/blob/422e1c345806f634ed92db2a67a672ed7e9c7101/values.yaml#L59). So if the MdaiCollector resource name is `hub-monitor`, the corresponding service endpoint created is `http://hub-monitor-mdai-collector-service.mdai.svc.cluster.local:4318`.
 
 #### Option B: Send hub component logs to a custom OTLP HTTP destination
 
-You can update the `values.yaml` for the [operator](https://github.com/DecisiveAI/mdai-helm-chart/blob/422e1c345806f634ed92db2a67a672ed7e9c7101/values.yaml#L52) and [event-handler-webservice](https://github.com/DecisiveAI/mdai-helm-chart/blob/422e1c345806f634ed92db2a67a672ed7e9c7101/values.yaml#L59) to send logs to a destination of your choosing that accepts OTLP HTTP logs.
+You can update the `values.yaml` for the [operator](https://github.com/DecisiveAI/mdai-helm-chart/blob/422e1c345806f634ed92db2a67a672ed7e9c7101/values.yaml#L52) and [mdai-gateway](https://github.com/DecisiveAI/mdai-helm-chart/blob/422e1c345806f634ed92db2a67a672ed7e9c7101/values.yaml#L59) to send logs to a destination of your choosing that accepts OTLP HTTP logs.
 
 #### Option C: Disable OTEL Logging for components in this chart
 
-If you do not want to send logs from these components, you can disable sending logs by updating the `values.yaml` by setting `mdai-operator.manager.env.otelSdkDisabled` and `event-handler-webservice.otelSdkDisabled` to `"true"` (a string value, not boolean).
+If you do not want to send logs from these components, you can disable sending logs by updating the `values.yaml` by setting `mdai-operator.manager.env.otelSdkDisabled` and `mdai-gateway.otelSdkDisabled` to `"true"` (a string value, not boolean).
 
 ---
 

--- a/files/dashboards/mdai-audit-stream.json
+++ b/files/dashboards/mdai-audit-stream.json
@@ -134,7 +134,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://event-handler-webservice.mdai.svc.cluster.local:8081/events",
+            "url": "http://mdai-gateway.mdai.svc.cluster.local:8081/events",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/templates/rabbitmq-secret.yaml
+++ b/templates/rabbitmq-secret.yaml
@@ -10,4 +10,3 @@ type: Opaque
 data:
   RABBITMQ_PASSWORD: {{ randAlphaNum 32 | b64enc | quote }}
   RABBITMQ_ENDPOINT: {{ printf "%s-rabbitmq.%s.svc.cluster.local:%d" .Release.Name .Release.Namespace (int .Values.rabbitmq.service.ports.amqp) | b64enc | quote }}
-  RABBITMQ_USER: mdai

--- a/values.yaml
+++ b/values.yaml
@@ -56,7 +56,7 @@ mdai-operator:
     certManager:
       enabled: true
 
-event-handler-webservice:
+mdai-gateway:
   enabled: true
   otelExporterOtlpEndpoint: http://hub-monitor-mdai-collector-service.mdai.svc.cluster.local:4318
   # otelSdkDisabled: "true"
@@ -99,7 +99,7 @@ kubeprometheusstack:
       - name: 'null'
       - name: 'event-handler'
         webhook_configs:
-          - url: 'http://event-handler-webservice.mdai.svc.cluster.local:8081/events'
+          - url: 'http://mdai-gateway.mdai.svc.cluster.local:8081/events'
             send_resolved: true
     serviceMonitor:
       selfMonitor: true


### PR DESCRIPTION
tested at local kind cluster
```
│ {"level":"info","timestamp":"2025-05-30T19:17:09.408Z","caller":"mdai-gateway/main.go:140","msg":"Successfully created EventHub","Endpoint":"mdai-rabbitmq.mdai.svc.cluster.local:5672"}                │
│ {"level":"info","timestamp":"2025-05-30T19:17:09.409Z","caller":"mdai-gateway/main.go:119","msg":"Starting server","address":":8081"} 
```