### PR TITLE
fix: Ds/eng 1349 parametrize greptimedb

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -30,10 +30,10 @@ dependencies:
   repository: oci://ghcr.io/mydecisive/charts
   version: 0.0.8
 - name: mdai-tracealyzer
-  repository: oci://ghcr.io/mydecisive/charts
-  version: 0.1.1
+  repository: file://../mdai-tracealyzer/deployment
+  version: 0.1.3
 - name: mdai-envoy-standalone
   repository: oci://ghcr.io/mydecisive/charts
   version: 0.1.0
-digest: sha256:83f28adc16a4451592f322801af32796e44a48997204fb343dc6b4b5c0267293
-generated: "2026-05-13T14:56:46.493656-04:00"
+digest: sha256:dcfc343e3a159c7c310bbbc6c2603b7383861b27e044b360a06521573f322e36
+generated: "2026-06-04T14:27:35.179919-04:00"

--- a/Chart.lock
+++ b/Chart.lock
@@ -30,10 +30,10 @@ dependencies:
   repository: oci://ghcr.io/mydecisive/charts
   version: 0.0.8
 - name: mdai-tracealyzer
-  repository: file://../mdai-tracealyzer/deployment
+  repository: oci://ghcr.io/mydecisive/charts
   version: 0.1.3
 - name: mdai-envoy-standalone
   repository: oci://ghcr.io/mydecisive/charts
   version: 0.1.0
-digest: sha256:dcfc343e3a159c7c310bbbc6c2603b7383861b27e044b360a06521573f322e36
-generated: "2026-06-04T14:27:35.179919-04:00"
+digest: sha256:f2af020074065c2eed685c79f15cbc457653b3fc7291f92acf4ab8bff4a05e7e
+generated: "2026-06-04T16:25:28.747707-04:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -47,7 +47,7 @@ dependencies:
     repository: oci://ghcr.io/mydecisive/charts
     condition: mdai-s3-logs-reader.enabled
   - name: mdai-tracealyzer
-    version: 0.1.1
+    version: 0.1.3
     repository: oci://ghcr.io/mydecisive/charts
     condition: mdai-tracealyzer.enabled
   - name: mdai-envoy-standalone

--- a/TRACEALYZER.md
+++ b/TRACEALYZER.md
@@ -1,8 +1,7 @@
-### Install MDAI with Tracealyzer
+### Install MDAI with Tracealyzer 
 ```bash
 helm upgrade --install --namespace mdai --create-namespace \
   --cleanup-on-fail --devel \
-  --values greptimedb-values.yaml \
   --values tracealyzer-values.yaml \
   --set greptimedb-standalone.enabled=true \
   --set mdai-tracealyzer.enabled=true \

--- a/TRACEALYZER.md
+++ b/TRACEALYZER.md
@@ -12,7 +12,6 @@ helm upgrade --install --namespace mdai --create-namespace \
 ```bash
 helm upgrade --install --namespace mdai --create-namespace \
 --cleanup-on-fail --devel \
---values greptimedb-values.yaml \
 --values tracealyzer-values.yaml \
 --values grafana-values.yaml \ 
 --set greptimedb-standalone.enabled=true \

--- a/greptimedb-values.yaml
+++ b/greptimedb-values.yaml
@@ -2,10 +2,19 @@ global:
   greptime:
 #   use 'public' unless mentioned database is explicitly created in GreptimeDB
     databaseName: public
-    nameOverride: ""
-    fullnameOverride: mdai-greptimedb
+#   always use fullnameOverride
+    fullnameOverride: &greptimeName mdai-greptimedb
+    postgresPort: &postgresPort 4003
+    mysqlPort: &mysqlPort 4002
+    grpcPort: &grpcPort 4001
+    httpPort: &httpPort 4000
 
 greptimedb-standalone:
+  fullnameOverride: *greptimeName
+  postgresServicePort: *postgresPort
+  mysqlServicePort: *mysqlPort
+  grpcServicePort: *grpcPort
+  httpServicePort: *httpPort
   extraVolumeMounts:
     - mountPath: /etc/greptimedb/auth
       name: auth

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -95,7 +95,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "greptimedb.host" -}}
+{{- $global := index .Values "global" | default dict -}}
+{{- $greptime := index $global "greptime" | default dict -}}
+{{- $fullnameOverride := index $greptime "fullnameOverride" | default "" -}}
+{{- if $fullnameOverride -}}
+{{- printf "%s.%s.svc.cluster.local" $fullnameOverride .Release.Namespace -}}
+{{- else -}}
 {{- printf "%s-greptimedb.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "greptimedb.psqlPort" -}}

--- a/tracealyzer-values.yaml
+++ b/tracealyzer-values.yaml
@@ -82,7 +82,7 @@ mdai-tracealyzer:
   image:
     repository: public.ecr.aws/decisiveai/mdai-tracealyzer
     pullPolicy: IfNotPresent
-    tag: "0.1.3"
+#    tag: "0.1.3"
 
   imagePullSecrets: []
   nameOverride: ""

--- a/tracealyzer-values.yaml
+++ b/tracealyzer-values.yaml
@@ -82,7 +82,7 @@ mdai-tracealyzer:
   image:
     repository: public.ecr.aws/decisiveai/mdai-tracealyzer
     pullPolicy: IfNotPresent
-    tag: "0.1.0"
+    tag: "0.1.3"
 
   imagePullSecrets: []
   nameOverride: ""

--- a/tracealyzer-values.yaml
+++ b/tracealyzer-values.yaml
@@ -1,3 +1,81 @@
+global:
+  greptime:
+#   use 'public' unless mentioned database is explicitly created in GreptimeDB
+    databaseName: public
+#   always use fullnameOverride
+    fullnameOverride: &greptimeName mdai-greptimedb
+    postgresPort: &postgresPort 4003
+    mysqlPort: &mysqlPort 4002
+    grpcPort: &grpcPort 4001
+    httpPort: &httpPort 4000
+
+greptimedb-standalone:
+  fullnameOverride: *greptimeName
+  postgresServicePort: *postgresPort
+  mysqlServicePort: *mysqlPort
+  grpcServicePort: *grpcPort
+  httpServicePort: *httpPort
+  extraVolumeMounts:
+    - mountPath: /etc/greptimedb/auth
+      name: auth
+      readOnly: true
+  extraVolumes:
+    - name: auth
+      secret:
+        defaultMode: 420
+        secretName: greptimedb-users-auth
+  env:
+    GREPTIMEDB_STANDALONE__USER_PROVIDER: "static_user_provider:file:/etc/greptimedb/auth/passwd"
+  ## AWS start
+  # objectStorage:
+  #   s3:
+  #     bucket: mdai-greptime-object-storage
+  #     endpoint: s3.us-east-2.amazonaws.com
+  #     region: us-east-2
+  #     root: ""
+  # persistence:
+  #   storageClass: gp2
+  #   size: 20Gi
+  # serviceAccount:
+  #   annotations:
+  #     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/mdai-greptime-irsa-role
+  #   create: true
+  #   name: greptimedb-standalone
+## AWS end
+
+
+kubeprometheusstack:
+  prometheus:
+    prometheusSpec:
+      retention: 3h
+      remoteRead:
+        - url: 'http://{{ .Values.global.greptime.fullnameOverride | default "mdai-greptimedb" }}.{{ .Release.Namespace }}.svc.cluster.local:4000/v1/prometheus/read?db={{ .Values.global.greptime.databaseName | default "public" }}'
+          basicAuth:
+            username:
+              name: greptimedb-users-auth
+              key: GREPTIME_USER
+            password:
+              name: greptimedb-users-auth
+              key: GREPTIME_PASSWD
+          requiredMatchers:
+            greptime_remote: "true"
+      remoteWrite:
+        - url: 'http://{{ .Values.global.greptime.fullnameOverride | default "mdai-greptimedb" }}.{{ .Release.Namespace }}.svc.cluster.local:4000/v1/prometheus/write?db={{ .Values.global.greptime.databaseName | default "public" }}'
+          basicAuth:
+            username:
+              name: greptimedb-users-auth
+              key: GREPTIME_USER
+            password:
+              name: greptimedb-users-auth
+              key: GREPTIME_PASSWD
+          writeRelabelConfigs:
+            - sourceLabels: [ job, __name__ ]
+              regex: '((mdai-observer-scrape|mdai-observer-otel-scrape|hub-monitor-scrape|otel-collector)|.*(-sampling-lb-collector|-trace-sampling-collector).*);.*|.*;(kube_pod_.*|container_.*|node_.*|kube_node_.*|process_.*)'
+              action: keep
+            - targetLabel: greptime_remote
+              replacement: "true"
+              action: replace
+
 mdai-tracealyzer:
   replicaCount: 1
 
@@ -48,9 +126,6 @@ mdai-tracealyzer:
       sweepInterval: "5s"
       # sweepWorkerPoolSize: 4  # defaults to runtime.NumCPU() when unset
     emitter:
-      greptimedbEndpoint: "mdai-greptimedb.mdai.svc.cluster.local:4001"
-      greptimedbSqlEndpoint: "mdai-greptimedb.mdai.svc.cluster.local:4003"
-      greptimedbDatabase: "public"
       tableTtl: "14d"
       timeout: "10s"
       maxRetries: 5


### PR DESCRIPTION

## Description
Adapt upgraded tracealyzer helm chart, that allows to use parametrized values for GreptimeDB endpoint name (base name, namespace)
I had to join greptimedb-values.yaml and tracealyzer-values.yaml for tracealyzer deployment, so I can use yaml anchors.
Recommended to use updated helm command to install MDAI with Tracealyzer (see TRACEALYZER.md for details)

- ENG-1349

## What type of PR is this? (only check one)


- [ ] Feature (`feat`)
- [x] Bug Fix (`fix`)
- [ ] Refactor (`refactor`)
- [ ] Documentation Update (`doc`)
- [ ] Other, please specify: 

### Does this PR introduce any breaking changes?
- [ ] No
- [x] Yes, and this is why:
 Helm command has changed
- [ ] I need help determining if there are any breaking changes

### Does the PR title type prefix match the selected type?
- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help select the right one

## Added/updated tests?
_Please keep the code coverage percentage at 80% and above._
- [ ] Yes
- [x] No, and this is why:
This is helm 
- [ ] I need help with writing tests

<!--
Uncomment this section if needed:
## Updated [`mdai-labs`](https://github.com/MyDecisive/mdai-labs) to reflect changes done in this PR?
- [ ] Yes
- [ ] N/A
- [ ] I need help, please elaborate: 
-->
