### PR TITLE
feat: new env variable, mdai-operator version bump up

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -18,8 +18,8 @@ dependencies:
   repository: https://greptimeteam.github.io/helm-charts
   version: 0.4.3
 - name: mdai-operator
-  repository: oci://ghcr.io/mydecisive/charts
-  version: 0.2.20
+  repository: file://../mdai-operator/deployment
+  version: 0.2.21
 - name: mdai-gateway
   repository: oci://ghcr.io/mydecisive/charts
   version: 0.1.10
@@ -35,5 +35,5 @@ dependencies:
 - name: mdai-envoy-standalone
   repository: oci://ghcr.io/mydecisive/charts
   version: 0.1.0
-digest: sha256:739a860c386277e9ff187491212694b48cf6424bbe237497da4f07abd1367dd1
-generated: "2026-06-16T10:11:11.367406-04:00"
+digest: sha256:0634067c20dc73e63e55682101fc2cce81a84413bebba2caa917bc0133fa147e
+generated: "2026-06-18T14:33:08.089505-04:00"

--- a/Chart.lock
+++ b/Chart.lock
@@ -18,7 +18,7 @@ dependencies:
   repository: https://greptimeteam.github.io/helm-charts
   version: 0.4.3
 - name: mdai-operator
-  repository: file://../mdai-operator/deployment
+  repository: oci://ghcr.io/mydecisive/charts
   version: 0.2.21
 - name: mdai-gateway
   repository: oci://ghcr.io/mydecisive/charts
@@ -35,5 +35,5 @@ dependencies:
 - name: mdai-envoy-standalone
   repository: oci://ghcr.io/mydecisive/charts
   version: 0.1.0
-digest: sha256:0634067c20dc73e63e55682101fc2cce81a84413bebba2caa917bc0133fa147e
-generated: "2026-06-18T14:33:08.089505-04:00"
+digest: sha256:ceb66c98115b1e52e98f15208d428bf548dac7687efc4b085e8b431afff61b74
+generated: "2026-06-25T16:14:31.067613-04:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     repository: https://greptimeteam.github.io/helm-charts
     condition: greptimedb-standalone.enabled
   - name: mdai-operator
-    version: 0.2.20
+    version: 0.2.21
     repository: oci://ghcr.io/mydecisive/charts
     condition: mdai-operator.enabled
   - name: mdai-gateway

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -123,6 +123,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $port -}}
 {{- end -}}
 
+{{- define "greptimedb.httpPort" -}}
+{{- $cfg := index .Values "greptimedb-standalone" -}}
+{{- $port := "4000" -}}
+{{- if and $cfg $cfg.httpServicePort -}}
+{{- $port = printf "%v" $cfg.httpServicePort -}}
+{{- end -}}
+{{- $port -}}
+{{- end -}}
+
 {{- define "greptimedb.database" -}}
 {{- $cfg := index .Values "greptimedb-standalone" -}}
 {{- $db := "public" -}}

--- a/templates/infra-setup-job.yaml
+++ b/templates/infra-setup-job.yaml
@@ -69,12 +69,14 @@ spec:
             GREPTIME_USER="{{ include "greptimedb.user" . }}"
             GREPTIME_MYSQL_PORT="{{ include "greptimedb.mysqlPort" . }}"
             GREPTIME_PSQL_PORT="{{ include "greptimedb.psqlPort" . }}"
+            GREPTIME_HTTP_PORT="{{ include "greptimedb.httpPort" . }}"
             kubectl create secret generic "$GREPTIME_SECRET" \
               --from-literal="GREPTIME_DATABASE=$GREPTIME_DATABASE" \
               --from-literal="GREPTIME_HOST=$GREPTIME_HOST" \
               --from-literal="GREPTIME_USER=$GREPTIME_USER" \
               --from-literal="GREPTIME_MYSQL_PORT=$GREPTIME_MYSQL_PORT" \
               --from-literal="GREPTIME_PSQL_PORT=$GREPTIME_PSQL_PORT" \
+              --from-literal="GREPTIME_HTTP_PORT=$GREPTIME_HTTP_PORT" \
               --from-literal="GREPTIME_PASSWD=$PW" \
               --from-literal="passwd=$AUTH"
 


### PR DESCRIPTION

## Description
- Adds new env variable to greptime db secret
- Bumps up mdai-operator version

- ENG-1332

## What type of PR is this? (only check one)
<!--
If you need to check more than one (except if the other type is `doc`, 
always do add more doc) to properly capture the PR type, please 
consider splitting up your PR.

If you selected Other, please ensure the type you provided
is one of the valid types outlined in
https://github.com/MyDecisive/changelogs?tab=readme-ov-file#type
-->

- [x] Feature (`feat`)
- [ ] Bug Fix (`fix`)
- [ ] Refactor (`refactor`)
- [ ] Documentation Update (`doc`)
- [ ] Other, please specify: 

### Does this PR introduce any breaking changes?
- [x] No
- [ ] Yes, and this is why: 
- [ ] I need help determining if there are any breaking changes

### Does the PR title type prefix match the selected type?
- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help select the right one

## Added/updated tests?
_Please keep the code coverage percentage at 80% and above._
- [ ] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests

<!--
Uncomment this section if needed:
## Updated [`mdai-labs`](https://github.com/MyDecisive/mdai-labs) to reflect changes done in this PR?
- [ ] Yes
- [ ] N/A
- [ ] I need help, please elaborate: 
-->
